### PR TITLE
heh... we're getting sloppy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "spudnik",
 	"description": "Spudnik is a free and open source Discord chat bot focused on guild management and adding interesting and useful functionality to your server. It was built on top of some of the most popular and widely used frameworks for extendibility, and written with organization and stability in mind. It also ships with ZERO weeb commands/references!",
-	"version": "0.9.3",
+	"version": "0.9.4",
 	"license": "Apache-2.0",
 	"readme": "README.md",
 	"engines": {

--- a/src/modules/mod/move.ts
+++ b/src/modules/mod/move.ts
@@ -141,7 +141,7 @@ export default class MoveCommand extends Command {
 						**Moderator:** ${msg.author.tag} (${msg.author.id})
 						**Member:** ${originalMessageAuthor.user.tag} (${originalMessageAuthor.id})
 						**Action:** Move
-						**Channels:** From- <#${originalChannel.id}> ==> To- <#${destinationChannel.id}
+						**Channels:** _from_ - <#${originalChannel.id}> > _to_ - <#${destinationChannel.id}>
 						**Reason:** ${args.reason}
 					`
 				}).setTimestamp();


### PR DESCRIPTION
fixed the `!move` command; the destination channel reference was missing a `>` which caused spudnik to just show the channel UUID